### PR TITLE
feat: add `data-extension="youtube"` to iframes generated form extension

### DIFF
--- a/YouTube.php
+++ b/YouTube.php
@@ -190,7 +190,7 @@ class YouTube {
 
 			if ( !empty( $ytid ) ) {
 				$url = $urlBase . $ytid . '?' . $argsStr;
-				$content = $iframe = "<iframe width=\"{$width}\" height=\"{$height}\" src=\"{$url}\" frameborder=\"0\" allowfullscreen></iframe>";
+				$content = $iframe = "<iframe data-extension="youtube" width=\"{$width}\" height=\"{$height}\" src=\"{$url}\" frameborder=\"0\" allowfullscreen></iframe>";
 				if ( $wgYouTubeEnableLazyLoad ) {
 					$img =
 						'<img width="' . $width . '" height="' . $height . '" src="'
@@ -294,7 +294,7 @@ class YouTube {
 			if ( !empty( $argv['playlist'] ) ) {
 				$uri .= "&playlist=" . (bool)$argv['playlist'];
 			}
-			return "<iframe src=\"$uri\" width=\"$width\" height=\"$height\" frameborder=\"0\" webkitallowfullscreen=\"true\" mozallowfullscreen=\"true\" allowfullscreen></iframe>";
+			return "<iframe data-extension="youtube" src=\"$uri\" width=\"$width\" height=\"$height\" frameborder=\"0\" webkitallowfullscreen=\"true\" mozallowfullscreen=\"true\" allowfullscreen></iframe>";
 		}
 	}
 


### PR DESCRIPTION
# Motivation

My team and I want to provide custom styling to the youtube embeds from the extension, however, the iframes created by the youtube extension don't have anything selectable by css apart from the iframe tag itself, which also applies the styles to iframes added by other extensions.

# Solution

I decided to add a data-attribute `data-extension="youtube"` as it carries no semantic meaning; a class would imply styles and id's would be hard to select in bulk. The data attribute is easily selectable by both CSS and JS.